### PR TITLE
fix: not working on Chrome

### DIFF
--- a/lancache-litmus/overlay/etc/nginx/sites-available/litmus.conf.d/10_litmus.conf
+++ b/lancache-litmus/overlay/etc/nginx/sites-available/litmus.conf.d/10_litmus.conf
@@ -1,5 +1,7 @@
 server_name lancache-litmus;
 
+add_header 'Access-Control-Allow-Private-Network' 'true';
+
 root /var/www/litmus;
 
 location /cache-test {


### PR DESCRIPTION
Requests to local LAN resources from WAN resources is disallowed per [CORS-RFC1918](https://wicg.github.io/private-network-access/).

Adding header `Access-Control-Allow-Private-Network` permits this access and fixes the litmus test on Chrome.