### PR TITLE
Part of #6 - Generate sites.js at build time

### DIFF
--- a/lancache-litmus/Dockerfile
+++ b/lancache-litmus/Dockerfile
@@ -1,4 +1,4 @@
-FROM lancachenet/ubuntu-nginx:latest
+FROM lancachenet/ubuntu-nginx:latest AS final
 MAINTAINER LanCache.Net Team <team@lancache.net>
 
 ENV WEBUSER www-data
@@ -25,3 +25,13 @@ VOLUME ["/var/www/litmus"]
 EXPOSE 80
 
 WORKDIR /scripts
+
+FROM final AS build-sites-js
+
+# Generate a sites.js
+RUN /bin/bash /hooks/entrypoint-pre.d/10_generate_litmus_statusjs.sh
+
+FROM final
+
+# Ship the generated sites.js
+COPY --from=build-sites-js /var/www/litmus/sites.js /var/www/litmus/sites.js


### PR DESCRIPTION
Generate a `sites.js` at build time, to enable the container to start without a network connection.